### PR TITLE
Configmap - node iam role arn reference in module locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Make all values of the tls_key variables not hardcoded values.
 - feat: Add the capacity for additional policies or override default attached policies to both the cluster and node group iam roles.
 
+## [3.0.2] - 2022-08-30
+fix: reference node iam arns inside the module for aws-auth configmap.
+
 ## [3.0.1] - 2022-08-26
 ### Description
-- fix: aws-auth configmap usage; ability to either create a new one or modify an existing one.
+- fix: aws-auth configmap usage; ability to either create a new one for self-managed node groups or modify an existing one.
 
 ## [3.0.0] - 2022-07-27
 ### Description
@@ -76,7 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cluster only example
 - Cluster logging
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-eks/compare/3.0.0...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-eks/compare/3.0.1...HEAD
+
+[3.0.2]: https://github.com/boldlink/terraform-aws-eks/releases/tag/3.0.2
 
 [3.0.1]: https://github.com/boldlink/terraform-aws-eks/releases/tag/3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ fix: reference node iam arns inside the module for aws-auth configmap.
 - Cluster only example
 - Cluster logging
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-eks/compare/3.0.1...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-eks/compare/3.0.2...HEAD
 
 [3.0.2]: https://github.com/boldlink/terraform-aws-eks/releases/tag/3.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - fix: Ensure all dynamic options both on module and submodules are present in the complete example.
 - fix: CKV_AWS_37: "Ensure Amazon EKS control plane logging enabled for all log types
+- fix: CKV_AWS_39: "Ensure Amazon EKS public endpoint disabled"
+- fix: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
 - fix: Use only one KMS key per module for secrets cloudwatch, and ebs.
 - feat: Add gp3 kms encryption for ebs volumes attached on the managed and self managed node groups (launch template).
 - feat: Add self-managed node-group for fully customizable cluster deployments, [for example windows node groups.](https://github.com/aws/containers-roadmap/issues/584).

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ module "minimum_eks_cluster" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.2 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,7 +19,7 @@ This example is for demo and testing purposes and doesn't represent a production
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,7 +29,7 @@ module "complete_eks_cluster" {
   encryption_config = {
     key_arn = local.kms_key_arn
   }
- 
+
   aws_auth_roles = [
     {
       rolearn  = "arn:aws:iam::12345678901:role/examplerole"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,8 +29,7 @@ module "complete_eks_cluster" {
   encryption_config = {
     key_arn = local.kms_key_arn
   }
-  aws_auth_node_iam_role_arns = flatten(concat(module.complete_eks_cluster.managed_role_arn, module.complete_eks_cluster.fargate_role_arn))
-
+ 
   aws_auth_roles = [
     {
       rolearn  = "arn:aws:iam::12345678901:role/examplerole"

--- a/examples/minimum/README.md
+++ b/examples/minimum/README.md
@@ -20,7 +20,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
 
 ## Modules
 

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,7 @@ locals {
   dns_suffix         = data.aws_partition.current.dns_suffix
   region             = data.aws_region.current.id
   partition          = data.aws_partition.current.partition
-  node_iam_role_arns = var.aws_auth_node_iam_role_arns
+  node_iam_role_arns = flatten(concat([for node in module.fargate_profile : node.role_arn ], [for node in module.node_group : node.role_arn], var.aws_auth_node_iam_role_arns))
   aws_auth_data = {
     mapRoles = yamlencode(concat(
       [for role_arn in local.node_iam_role_arns : {

--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,7 @@ locals {
   dns_suffix         = data.aws_partition.current.dns_suffix
   region             = data.aws_region.current.id
   partition          = data.aws_partition.current.partition
-  node_iam_role_arns = flatten(concat([for node in module.fargate_profile : node.role_arn ], [for node in module.node_group : node.role_arn], var.aws_auth_node_iam_role_arns))
+  node_iam_role_arns = flatten(concat([for node in module.fargate_profile : node.role_arn], [for node in module.node_group : node.role_arn], var.aws_auth_node_iam_role_arns))
   aws_auth_data = {
     mapRoles = yamlencode(concat(
       [for role_arn in local.node_iam_role_arns : {

--- a/modules/fargate-profile/README.md
+++ b/modules/fargate-profile/README.md
@@ -38,7 +38,7 @@ module "fargate_profile" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
 
 ## Modules
 

--- a/modules/managed-node-group/README.md
+++ b/modules/managed-node-group/README.md
@@ -56,9 +56,9 @@ module "node_group" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.2 |
 
 ## Modules
 

--- a/tests/supportingResources/README.md
+++ b/tests/supportingResources/README.md
@@ -24,7 +24,7 @@ This stack builds:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.27.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.28.0 |
 
 ## Modules
 


### PR DESCRIPTION
# Description

This PR aims to modify aws-auth configmap to reference the node iam roles at the module level, as compared to adding them at the stack level.

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-eks/blob/fix/configmap-role-arns/CHANGELOG.md#302---2022-08-30)

## Checklists:
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
